### PR TITLE
Create default test context + url + version bump

### DIFF
--- a/pytest_talisker/fixtures.py
+++ b/pytest_talisker/fixtures.py
@@ -1,0 +1,9 @@
+import pytest
+
+import talisker
+
+@pytest.fixture(scope="session", autouse=True)
+def talisker_ctx():
+    """Ensure that all tests run under a talisker test context"""
+    with talisker.testing.TestContext() as ctx:
+        yield ctx

--- a/pytest_talisker/pluginmodule.py
+++ b/pytest_talisker/pluginmodule.py
@@ -6,3 +6,5 @@ talisker.logs.configure_test_logging()  # noqa
 
 import talisker.testing
 talisker.testing.configure_testing()
+
+from .fixtures import talisker_ctx

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 from setuptools import setup
 
 setup(
-    version = '0.1.0',
+    version = '0.2.0',
     name="pytest-talisker",
     packages=["pytest_talisker"],
+    url="https://github.com/canonical-ols/pytest-talisker",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["talisker = pytest_talisker.pluginmodule"]},
     install_requires=["talisker", ],


### PR DESCRIPTION
Move the needed talisker test context to an fixture provided by the
module. With this change, all tests will run under a test context as is
expected by talisker.

Also added a source url and bumped the version.